### PR TITLE
Fix assignment logic in FileSystemEntry constructor

### DIFF
--- a/DiskAccessLibrary/FileSystems/Abstractions/FileSystemEntry.cs
+++ b/DiskAccessLibrary/FileSystems/Abstractions/FileSystemEntry.cs
@@ -34,8 +34,8 @@ namespace DiskAccessLibrary.FileSystems.Abstractions
             LastWriteTime = lastWriteTime;
             LastAccessTime = lastAccessTime;
             IsHidden = isHidden;
-            IsReadonly = isHidden;
-            IsArchived = isHidden;
+            IsReadonly = isReadonly;
+            IsArchived = isArchived;
 
             if (isDirectory)
             {


### PR DESCRIPTION
The original code mistakenly assigned the `isHidden` value to `IsReadonly` and `IsArchived`. This commit corrects the assignment to use the correct `isReadonly` and `isArchived` parameters.