### PR TITLE
Fix VHD parent unicode name not being in big endian

### DIFF
--- a/DiskAccessLibrary/Disks/VHD/DynamicDiskHeader.cs
+++ b/DiskAccessLibrary/Disks/VHD/DynamicDiskHeader.cs
@@ -65,7 +65,7 @@ namespace DiskAccessLibrary.VHD
             ParentUniqueID = BigEndianConverter.ToGuid(buffer, 0x28);
             ParentTimeStamp = BigEndianConverter.ToUInt32(buffer, 0x38);
             Reserved = BigEndianConverter.ToUInt32(buffer, 0x3C);
-            ParentUnicodeName = ByteReader.ReadUTF16String(buffer, 0x40, 256).TrimEnd('\0');
+            ParentUnicodeName = ByteReader.ReadUTF16BEString(buffer, 0x40, 256).TrimEnd('\0');
             ParentLocatorEntry1 = new ParentLocatorEntry(buffer, 0x240);
             ParentLocatorEntry2 = new ParentLocatorEntry(buffer, 0x258);
             ParentLocatorEntry3 = new ParentLocatorEntry(buffer, 0x270);
@@ -94,7 +94,7 @@ namespace DiskAccessLibrary.VHD
             BigEndianWriter.WriteGuid(buffer, 0x28, ParentUniqueID);
             BigEndianWriter.WriteUInt32(buffer, 0x38, ParentTimeStamp);
             BigEndianWriter.WriteUInt32(buffer, 0x3C, Reserved);
-            ByteWriter.WriteUTF16String(buffer, 0x40, ParentUnicodeName, 256);
+            ByteWriter.WriteUTF16BEString(buffer, 0x40, ParentUnicodeName, 256);
             ParentLocatorEntry1.WriteBytes(buffer, 0x240);
             ParentLocatorEntry2.WriteBytes(buffer, 0x258);
             ParentLocatorEntry3.WriteBytes(buffer, 0x270);


### PR DESCRIPTION
As per VHD specification:

> All values in the file format, unless otherwise specified, are stored in network byte order (big endian)

I've checked VHD files created by Windows itself, and parent name is in big endian. Another implementation conforming to this can be found [here](https://github.com/DiscUtils/DiscUtils/blob/59d7cadab839c6d8dfcf52f8be5efe6d2ced190f/Library/DiscUtils.Vhd/DynamicHeader.cs#L98)

_I didn't thoroughly tested this, as locally I had to inherit `DynamicDiskHeader` to monkey-patch it without forking the library, so my setup is a bit different than in this PR. And there are no UTs for VHD here AFAIK_